### PR TITLE
Proper ordering of classes in output/minimized forward declarations

### DIFF
--- a/ReClass/ClassDependencyGraph.cpp
+++ b/ReClass/ClassDependencyGraph.cpp
@@ -1,0 +1,172 @@
+#include "stdafx.h"
+#include "ClassDependencyGraph.h"
+
+
+bool DependencyNode::AddInEdge(const DependencyNode* parent, const DependencyType edgeType) {
+	DependencyEdge newEdge(parent, edgeType);
+	//
+	// We do not allow parallel edges, so we check to make sure this edge doesn't already exist.
+	// We COULD have used a map for the dependencies container.  But, most classes probably won't
+	// have a ton of dependencies, so a vector makes sense for our more average case.
+	//
+	for (auto edge : this->inEdges) {
+		if (edge == newEdge) {
+			return false;
+		}
+	}
+	this->inEdges.push_back(newEdge);
+	return true;
+}
+
+const std::vector<DependencyEdge>* DependencyNode::GetDependencies() const {
+	return &this->dependencies;
+}
+
+bool DependencyNode::AddDependency(const DependencyNode* dep, const DependencyType edgeType) {
+	DependencyEdge newEdge(dep, edgeType);
+	//
+	// We do not allow parallel edges, so we check to make sure this edge doesn't already exist.
+	// We COULD have used a map for the dependencies container.  But, most classes probably won't
+	// have a ton of dependencies, so a vector makes sense for our more average case.
+	//
+	for (auto edge : this->dependencies) {
+		if (edge == newEdge) {
+			return false;
+		}
+	}
+	this->dependencies.push_back(newEdge);
+	return true;
+}
+
+
+std::vector<DependencyNode*> ClassDependencyGraph::GetLeafNodes() {
+	std::vector<DependencyNode*> result;
+	for (auto it = nodes.begin(); it != nodes.end(); it++) {
+		if (it->second.GetInEdges()->size() == 0) {
+			result.push_back(&it->second);
+		}
+	}
+	return result;
+}
+
+std::vector<DependencyNode*> ClassDependencyGraph::GetInstanceNodes() {
+	std::vector<DependencyNode*> result;
+	for (auto it = nodes.begin(); it != nodes.end(); it++) {
+		bool hasOutInstanceEdge = false;
+		
+		for (auto inEdge : *it->second.GetInEdges()) {
+			if (inEdge.edgeType == DependencyType::INSTANCE) {
+				hasOutInstanceEdge = true;
+				break;
+			}
+		}
+		if (hasOutInstanceEdge) {
+			result.push_back(&it->second);
+		}
+	}
+	return result;
+}
+
+int ClassDependencyGraph::ProcessDependencies(DependencyEdge* edge, std::map<const DependencyNode*, NodeGenerationStatus>& nodeStatus, std::set<const CNodeClass*>& forwardDeclarations, std::vector<const CNodeClass*> &classDefinitions) {
+	int classesAdded = 0;
+	NodeGenerationStatus nodeGenStatus;
+	const DependencyNode* node = edge->dependency;
+	if (nodeStatus.find(node) == nodeStatus.end()) {
+		nodeStatus[node] = NodeGenerationStatus::UNPROCESSED;
+	}
+	nodeGenStatus = nodeStatus[node];
+	// We have to treat instanced nodes differently, since they have 'hard' dependencies
+	// on their parent classes.  If we come across an instanced node through a pointer, 
+	// we will forward declare it because if we try to process it like normal we may end
+	// up with a back edge to its parent that will break everything.
+	//
+	// If we come upon an instanced node througn an instance, we process it like normal.
+	if (nodeGenStatus == NodeGenerationStatus::INSTANCED) {
+		if (edge->edgeType == DependencyType::POINTER) {
+			forwardDeclarations.insert(node->GetCClass());
+			return 0;
+		}
+		else if (edge->edgeType == DependencyType::INSTANCE) {
+			// Change nodeGenStatys to trigger the actual processing of the node
+			nodeGenStatus = NodeGenerationStatus::UNPROCESSED;
+		}
+	}
+	if (nodeGenStatus == NodeGenerationStatus::PROCESSED) {
+		// The node is already written to the output, no further processing needed
+		return classesAdded;
+	}
+	else if (nodeGenStatus == NodeGenerationStatus::PROCESSING) {
+		// We've hit a back edge.  Since we start from leaf nodes, this dependency cannot
+		// possibly be an instance dependency, it must be a pointer dependency.  Thus, a 
+		// forward declaration is enough to handle this case.
+		ASSERT(edge->edgeType == DependencyType::POINTER);
+		forwardDeclarations.insert(node->GetCClass());
+		// While it isn't actually finished processing, if we leave it as PROCESSING we'll
+		// get a new forward declaration every time we hit this node.  If it's currently 
+		// processing, somewhere up the call stack is the actual processing of this node
+		// so on return it'll get finished up.
+		nodeStatus[node] = NodeGenerationStatus::PROCESSED;
+	}
+	else {
+		// Case where processing has yet to begin.  We need to recursively process all dependencies, 
+		// then add this class to the ordered list of definitions.
+		nodeStatus[node] = NodeGenerationStatus::PROCESSING;
+		for (auto dep : *node->GetDependencies()) {
+			if (dep.edgeType == DependencyType::INSTANCE)
+				classesAdded += ProcessDependencies(&dep, nodeStatus, forwardDeclarations, classDefinitions);
+		}
+		for (auto dep : *node->GetDependencies()) {
+			if (dep.edgeType == DependencyType::POINTER)
+				classesAdded += ProcessDependencies(&dep, nodeStatus, forwardDeclarations, classDefinitions);
+		}
+		classDefinitions.push_back(node->GetCClass());
+		nodeStatus[node] = NodeGenerationStatus::PROCESSED;
+		classesAdded += 1;
+	}
+	return classesAdded;
+}
+
+std::string ClassDependencyGraph::ToDot(std::string graphLabel) {
+	std::stringstream stream;
+	stream << "digraph class_dependency {";
+	for (auto node : this->nodes) {
+		for (auto edge : *node.second.GetDependencies()) {
+			stream << "\"";
+			stream << CT2CA(node.first->GetName());
+			stream << "\"";
+			stream << " -> ";
+			stream << "\"";
+			stream << CT2CA(edge.dependency->GetCClass()->GetName());
+			stream << "\"";
+			if (edge.edgeType == DependencyType::POINTER) {
+				stream << " [style=dotted]";
+			}
+			stream << ";";
+			stream << "\n";
+		}
+	}
+	stream << "}";
+	return stream.str();
+}
+
+int ClassDependencyGraph::OrderClassesForGeneration(std::set<const CNodeClass*>& forwardDeclarations, std::vector<const CNodeClass*>& classDefinitions) {
+	int classesAdded = 0;
+	std::map<const DependencyNode*, NodeGenerationStatus> nodeStatus;
+	std::vector<DependencyNode*> leafNodes			= this->GetLeafNodes();
+	std::vector<DependencyNode*> instancedNodes		= this->GetInstanceNodes();
+
+	for (auto node : instancedNodes) {
+		nodeStatus[node] = NodeGenerationStatus::INSTANCED;
+	}
+
+	for (auto leaf : leafNodes) {
+		for (auto dep : *leaf->GetDependencies()) {
+			classesAdded += ProcessDependencies(&dep, nodeStatus, forwardDeclarations, classDefinitions);
+		}
+		classDefinitions.push_back(leaf->GetCClass());
+		classesAdded += 1;
+	 }
+
+	 return classesAdded;
+ }
+

--- a/ReClass/ClassDependencyGraph.h
+++ b/ReClass/ClassDependencyGraph.h
@@ -1,0 +1,81 @@
+#pragma once
+#include "CNodeClass.h"
+
+#include <assert.h>
+#include <atlbase.h>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <set>
+#include <string>
+#include <sstream>
+#include <vector>
+
+class DependencyNode;
+
+enum class DependencyType {
+	POINTER,
+	INSTANCE
+};
+
+struct DependencyEdge {
+	const DependencyNode* dependency;
+	const DependencyType	edgeType;
+
+	DependencyEdge(const DependencyNode* dependency, const DependencyType edgeType) : dependency(dependency), edgeType(edgeType) {};
+	bool operator==(const DependencyEdge& other) const {
+		return this->dependency == other.dependency && this->edgeType == other.edgeType;
+	}
+};
+
+class DependencyNode {
+	const CNodeClass* cClass = nullptr;
+	std::vector<DependencyEdge> dependencies;
+	std::vector<DependencyEdge> inEdges;
+public:
+	DependencyNode() {};
+	DependencyNode(const CNodeClass* cClass) : cClass(cClass) {};
+	const std::vector<DependencyEdge>* GetDependencies() const;
+	const std::vector<DependencyEdge>* GetInEdges() const { return &this->inEdges; }
+	const CNodeClass* GetCClass() const { return this->cClass; }
+	bool AddDependency(const DependencyNode* dep, const DependencyType edgeType);
+	bool AddInEdge(const DependencyNode* parent, const DependencyType edgeType);
+};
+
+class ClassDependencyGraph {
+	std::map<const CNodeClass*, DependencyNode> nodes;
+	
+	std::vector<DependencyNode*> GetLeafNodes();
+	std::vector<DependencyNode*> GetInstanceNodes();
+	enum class NodeGenerationStatus {
+		UNPROCESSED,
+		PROCESSING,
+		PROCESSED,
+		INSTANCED
+	};
+	int ProcessDependencies(DependencyEdge *node, std::map<const DependencyNode*, NodeGenerationStatus> &nodeStatus, std::set<const CNodeClass*>& forwardDeclarations, std::vector<const CNodeClass*> &classDefinitions);
+
+
+public:
+	bool AddNode(const CNodeClass* node) {
+		if (this->nodes.find(node) == this->nodes.end()) {
+			this->nodes[node] = DependencyNode(node);
+			return true;
+		}
+		return false;
+	}
+
+	bool AddEdge(const CNodeClass *dependingClass, const CNodeClass* dependency, DependencyType depType) {
+		// Ignore simple recursion in the dependency graph.  It won't help in our analysis and will just muddy
+		// up the graph.
+		if (dependingClass == dependency) {
+			return false;
+		}
+		DependencyNode* dependingNode = &this->nodes[dependingClass];
+		DependencyNode* dependencyNode = &this->nodes[dependency];
+		dependencyNode->AddInEdge(dependingNode, depType);
+		return dependingNode->AddDependency(dependencyNode, depType);
+	}
+	std::string ToDot(std::string graphLabel = "");
+	int OrderClassesForGeneration(std::set<const CNodeClass*>& forwardDeclarations, std::vector<const CNodeClass*> &classDefinitions);
+};

--- a/ReClass/ReClassEx.h
+++ b/ReClass/ReClassEx.h
@@ -10,6 +10,8 @@
 #include "DialogConsole.h"
 // Symbols
 #include "Symbols.h"
+// Class dependency graph
+#include "ClassDependencyGraph.h"
 
 class CReClassExApp : public CWinAppEx {
 public:

--- a/ReClass/ReClassEx.vcxproj
+++ b/ReClass/ReClassEx.vcxproj
@@ -332,6 +332,7 @@
   <ItemGroup>
     <ClInclude Include="CCustomEdit.h" />
     <ClInclude Include="CCustomToolTip.h" />
+    <ClInclude Include="ClassDependencyGraph.h" />
     <ClInclude Include="CNodeArray.h" />
     <ClInclude Include="CNodeBase.h" />
     <ClInclude Include="CNodeBits.h" />
@@ -413,6 +414,7 @@
     <ClCompile Include="CCustomToolTip.cpp" />
     <ClCompile Include="CClassFrame.cpp" />
     <ClCompile Include="CClassView.cpp" />
+    <ClCompile Include="ClassDependencyGraph.cpp" />
     <ClCompile Include="CNodeArray.cpp" />
     <ClCompile Include="CNodeBase.cpp" />
     <ClCompile Include="CNodeBits.cpp" />

--- a/ReClass/ReClassEx.vcxproj.filters
+++ b/ReClass/ReClassEx.vcxproj.filters
@@ -392,6 +392,9 @@
     <ClInclude Include="CNodePtrArray.h">
       <Filter>Header Files\Nodes</Filter>
     </ClInclude>
+    <ClInclude Include="ClassDependencyGraph.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -567,6 +570,9 @@
     </ClCompile>
     <ClCompile Include="CNodePtrArray.cpp">
       <Filter>Source Files\Nodes</Filter>
+    </ClCompile>
+    <ClCompile Include="ClassDependencyGraph.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I added some changes to make the generated classes compile properly without having to be manually reordered.

Summary:

* When the 'generate' button is clicked, each class is added to a Class Dependency Graph, and each class that class references is added as a depenedency.
* There are two dependency types - POINTER and INSTANCE.
    * POINTER references can be solved with a forward declaration.  However, a simple reordering can solve that dependency and limit the forward declaration spam at the top of the generated file.
    * INSTANCE references can only be solved with reordering.  If class B contains an instance of class A, A must come before B in the generated file, no way around it.
* The graph is then recursively traversed - starting at nodes with no dependents - with classes being added to the 'ordered' class collection.
* Circular dependencies (A points to B points to C points to A) are solved with forward declarations (C comes before B comes before A, with A being forward declared)
* The result is the output has fewer forward declarations and classes don't need to be manually reordered.  In my DayZ Reclass file (which inspired this work, because it takes me a lot of time manually reordering every time I generate the output) there are only 5 forward declarations with 356 classes.

Details:

The graph class itself is pretty simple.  It maintains a mapping of CNodeClass pointers to DependencyNodes.  Each node knows what class it represents, and has two vectors of edges - incoming edges (another class depends on this one) and outgoing edges (this class depends on another).  Each edge knows what node it points to, as well as whether the dependency is of POINTER or INSTANCE type.

Edges are generated by walking each node in a class and adding a dependency edge for each pointer, instance, instance array, and pointer array.  Parallel edges (duplicates) are not added, nor are simple recursive edges (a class has a pointer to an instance of that same class).  Other types (function ptrs?  Can we prototype those in ReClass?) may be necessary here, but these were all I could figure out without asking someone.

```
ClassDependencyGraph            depGraph;
    // Add each class as a node to the graph before adding dependency edges
    for (auto cNode : this->m_Classes) {
        depGraph.AddNode(cNode);
    }
    for (auto cNode : this->m_Classes) {
        for (size_t n = 0; n < cNode->NodeCount(); n++)
        {
            CNodeBase* pNode = (CNodeBase*)cNode->GetNode(n);
            NodeType Type = pNode->GetType();
            switch (Type) {
            case(nt_pointer):
            {
                CNodePtr* pPointer = (CNodePtr*)pNode;
                CNodeClass* pointerClass = pPointer->GetClass();
                depGraph.AddEdge(cNode, pointerClass, DependencyType::POINTER);
                break;
            }
            case(nt_instance):
            {
                CNodeClassInstance* pClassInstance = (CNodeClassInstance*)pNode;
                CNodeClass* instanceClass = pClassInstance->GetClass();
                depGraph.AddEdge(cNode, instanceClass, DependencyType::INSTANCE);
                break;
            }

            case(nt_array):
            {
                CNodeArray* pArray = (CNodeArray*)pNode;
                CNodeClass* instanceClass = pArray->GetClass();
                depGraph.AddEdge(cNode, instanceClass, DependencyType::INSTANCE);
                break;
            }

            case(nt_ptrarray):
            {
                CNodePtrArray* pArray = (CNodePtrArray*)pNode;
                CNodeClass* pointerClass = pArray->GetClass();
                depGraph.AddEdge(cNode, pointerClass, DependencyType::POINTER);
                break;
            }
            }
        }
    }

```
Ordering dependencies in the graph is simple in naive cases.  Just start at nodes that have no dependents (leaf nodes) and recursively visit dependencies, adding them to an ordered class vector as you go.  This works great until you hit circular dependencies - you'd recurse until death.  That's where forward declarations are needed.  If you hit a node that is already being processed, you know you've thrown that ass in a circle.  So that's when you throw your hands up and forward declare - but you can only do that for a POINTER dependency, not an INSTANCE one.

![image](https://user-images.githubusercontent.com/4275220/120218091-3bdf9480-c207-11eb-9368-387ef2fe1cb8.png)

(dotted lines are POINTER dependencies, solid lines are INSTANCE dependencies)

You can see in this graph that DayZPlayer instances Entity which points to physicsObject which points to DayZPlayer.  And if that's the order you hit the nodes in, you're fine - just forward declare DayZPlayer.  However, there exists a path from gpWorld -> World -> N0000120E -> Entity -> PhysicsObject -> DayZPlayer -> Entity.  In that case, when you realize you're in a cycle you're at an INSTANCE dependency and you can't solve it with a forward declaration.

I wasn't sure what the correct way to handle this was, so I kind of improvised a solution.  At the beginning of graph solving, all nodes which have incoming INSTANCE type dependencies are marked.  Then, when they're visited during recursion, if they're being visited across a POINTER dependency edge, they're forward declared and not processed further.  So when you hit gpWorld -> World -> N0000120E -> Entity, it knows Entity has incoming INSTANCE dependencies, so instead of recursing and ending up in DayZPlayer, it adds a forward declaration for Entity and bails out.  Then, later (and along a different path that doesn't go through Entity), DayZPlayer is visited normally and it recurses into Entity, and all is well.

With forward declarations generated and the classes in dependency order, output goes on as normal, except instead of iterating of m_Classes, it iterates over the set of forward declarations and the in-order vector of classes instead.

A portion of the output demonstrating the minimized forward declarations and dependency-based ordering.  It's not a great example, but I haven't really been game hacking lately I've been doing other research, so my classes aren't all that robust.

```
// Generated using ReClassEx

class DayZPlayer;
class VoNSystemXA2;
class NetChannelBasic;
class ServerQueryResponse;
class WinEngine;

class N000006ED
{
public:
	char pad_0x0000[0x8]; //0x0000

}; //Size=0x0008

class packet
{
public:
	WORD length; //0x0000 
	__int16 flags; //0x0002 
	__int32 hash; //0x0004 
	DWORD serial; //0x0008 
	DWORD origin; //0x000C 
	DWORD control1; //0x0010 
	DWORD control2; //0x0014 
	char pad_0x0018[0x48]; //0x0018

}; //Size=0x0060

class N000005AD
{
public:
	char pad_0x0000[0x8]; //0x0000

}; //Size=0x0008

class NetMessage
{
public:
	char pad_0x0000[0x10]; //0x0000
	N000006ED* parentChannel; //0x0010 
	char pad_0x0018[0x10]; //0x0018
	packet* message; //0x0028 
	char pad_0x0030[0x38]; //0x0030
	N000005AD* N0000053A; //0x0068 
	char pad_0x0070[0x18]; //0x0070
	DWORD serial; //0x0088 
	char pad_0x008C[0x4]; //0x008C
	NetMessage* N0000053F; //0x0090 

}; //Size=0x0098

class N000007BF
{
public:
	NetMessage* N000007C0; //0x0000 
	char pad_0x0008[0x40]; //0x0008

}; //Size=0x0048

class N00000719
{
public:
	char pad_0x0000[0x448]; //0x0000

}; //Size=0x0448

class NetMessagePool
{
public:
	char pad_0x0000[0x78]; //0x0000
	N000007BF* N000006FD; //0x0078 
	char pad_0x0080[0x50]; //0x0080
	N00000719* N00000708; //0x00D0 
	char pad_0x00D8[0x18]; //0x00D8

}; //Size=0x00F0

class gpNetMessagePool
{
public:
	NetMessagePool* N000006E4; //0x0000 
	char pad_0x0008[0x38]; //0x0008

}; //Size=0x0040
```

To generate the visualized graph, I put a ToDot method in the DependencyGraph, which generates a GraphViz Dot representation of the graph.  I left it in as it may end up being useful in troubleshooting in the future.